### PR TITLE
Update index.js

### DIFF
--- a/models/index.js
+++ b/models/index.js
@@ -8,7 +8,7 @@ var fs        = require('fs')
 fs
   .readdirSync(__dirname)
   .filter(function(file) {
-    return (file.indexOf('.') !== 0) && (file !== 'index.js')
+    return ((file.indexOf('.') !== 0) && (file !== 'index.js') && (file.slice(-3) == '.js'))
   })
   .forEach(function(file) {
     var model = sequelize.import(path.join(__dirname, file))


### PR DESCRIPTION
prevents models/index.js from reading in backup/autosave files generated by texteditors. (eg. emacs appends "~" for backup files, wraps "#" around file names for autosave files)
