### PR TITLE
Add feature to destroy individual users

### DIFF
--- a/routes/users.js
+++ b/routes/users.js
@@ -10,6 +10,21 @@ router.post('/create', function(req, res) {
   });
 });
 
+router.get('/:user_id/destroy', function(req, res) {
+  models.User.find({
+    where: {id: req.param('user_id')},
+    include: [models.Task]
+  }).success(function(user) {
+    models.Task.destroy(
+      {where: {UserId: user.id}}
+    ).success(function(affectedRows) {
+      user.destroy().success(function() {
+        res.redirect('/');
+      });
+    });
+  });
+});
+
 router.post('/:user_id/tasks/create', function (req, res) {
   models.User.find({
     where: { id: req.param('user_id') }

--- a/views/index.jade
+++ b/views/index.jade
@@ -15,6 +15,10 @@ block content
   each user in users
     li
       = user.username
+      | &nbsp;
+      | (
+      a(href="/users/" + user.id + "/destroy") Destroy
+      | )
       ul
         li
           | Creating a new task:


### PR DESCRIPTION
Seemed like a natural addition to contribute to the cause.  Thanks for this helpful example of using Sequelize with Express.  

Ideally, the code should eventually be upgraded to reflect the change in handling the return of results for Sequelize 2.0.  E.g. .success is now deprecated and .then should be used instead.  See https://github.com/sequelize/sequelize/wiki/Upgrading-to-2.0 .     
