### PR TITLE
Use Promises instead of EventEmitter for handling return results

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ var models = require("../models");
 
 app.set('port', process.env.PORT || 3000);
 
-models.sequelize.sync().success(function () {
+models.sequelize.sync().then(function () {
   var server = app.listen(app.get('port'), function() {
     debug('Express server listening on port ' + server.address().port);
   });

--- a/bin/www
+++ b/bin/www
@@ -6,7 +6,7 @@ var models = require("../models");
 
 app.set('port', process.env.PORT || 3000);
 
-models.sequelize.sync().success(function () {
+models.sequelize.sync().then(function () {
   var server = app.listen(app.get('port'), function() {
     debug('Express server listening on port ' + server.address().port);
   });

--- a/routes/index.js
+++ b/routes/index.js
@@ -5,7 +5,7 @@ var router  = express.Router();
 router.get('/', function(req, res) {
   models.User.findAll({
     include: [ models.Task ]
-  }).success(function(users) {
+  }).then(function(users) {
     res.render('index', {
       title: 'Express',
       users: users

--- a/routes/users.js
+++ b/routes/users.js
@@ -5,7 +5,7 @@ var router  = express.Router();
 router.post('/create', function(req, res) {
   models.User.create({
     username: req.param('username')
-  }).success(function() {
+  }).then(function() {
     res.redirect('/');
   });
 });
@@ -14,11 +14,11 @@ router.get('/:user_id/destroy', function(req, res) {
   models.User.find({
     where: {id: req.param('user_id')},
     include: [models.Task]
-  }).success(function(user) {
+  }).then(function(user) {
     models.Task.destroy(
       {where: {UserId: user.id}}
-    ).success(function(affectedRows) {
-      user.destroy().success(function() {
+    ).then(function(affectedRows) {
+      user.destroy().then(function() {
         res.redirect('/');
       });
     });
@@ -28,11 +28,11 @@ router.get('/:user_id/destroy', function(req, res) {
 router.post('/:user_id/tasks/create', function (req, res) {
   models.User.find({
     where: { id: req.param('user_id') }
-  }).success(function(user) {
+  }).then(function(user) {
     models.Task.create({
       title: req.param('title')
-    }).success(function(title) {
-      title.setUser(user).success(function() {
+    }).then(function(title) {
+      title.setUser(user).then(function() {
         res.redirect('/');
       });
     });
@@ -42,12 +42,12 @@ router.post('/:user_id/tasks/create', function (req, res) {
 router.get('/:user_id/tasks/:task_id/destroy', function (req, res) {
   models.User.find({
     where: { id: req.param('user_id') }
-  }).success(function(user) {
+  }).then(function(user) {
     models.Task.find({
       where: { id: req.param('task_id') }
-    }).success(function(task) {
-      task.setUser(null).success(function() {
-        task.destroy().success(function() {
+    }).then(function(task) {
+      task.setUser(null).then(function() {
+        task.destroy().then(function() {
           res.redirect('/');
         });
       });


### PR DESCRIPTION
I thought I'd go ahead and do it.  :)

Return results now use core Promise methods rather than the EventEmitter methods from Sequelize.  The latter are now deprecated with Sequelize version 2.0.  E.g. .success is replaced by .then.  For more info about the Sequelize upgrade see:  https://github.com/sequelize/sequelize/wiki/Upgrading-to-2.0 

FYI, Sequelize now uses the BlueBird Promises library.  For info on that, see: https://github.com/petkaantonov/bluebird 

Note that this project is an example of using Sequelize with Express.  There's currently minimal handling of rejection return results and other errors. 
