### PR TITLE
simplify code

### DIFF
--- a/models/task.js
+++ b/models/task.js
@@ -6,7 +6,12 @@ module.exports = function(sequelize, DataTypes) {
   }, {
     classMethods: {
       associate: function(models) {
-        Task.belongsTo(models.User);
+        Task.belongsTo(models.User, {
+          onDelete: "CASCADE",
+          foreignKey: {
+            allowNull: false
+          }
+        });
       }
     }
   });

--- a/routes/users.js
+++ b/routes/users.js
@@ -11,47 +11,31 @@ router.post('/create', function(req, res) {
 });
 
 router.get('/:user_id/destroy', function(req, res) {
-  models.User.find({
-    where: {id: req.param('user_id')},
-    include: [models.Task]
-  }).then(function(user) {
-    models.Task.destroy(
-      {where: {UserId: user.id}}
-    ).then(function(affectedRows) {
-      user.destroy().then(function() {
-        res.redirect('/');
-      });
-    });
+  models.User.destroy({
+    where: {
+      id: req.param('user_id')
+    }
+  }).then(function() {
+    res.redirect('/');
   });
 });
 
 router.post('/:user_id/tasks/create', function (req, res) {
-  models.User.find({
-    where: { id: req.param('user_id') }
-  }).then(function(user) {
-    models.Task.create({
-      title: req.param('title')
-    }).then(function(title) {
-      title.setUser(user).then(function() {
-        res.redirect('/');
-      });
-    });
+  models.Task.create({
+    title: req.param('title'),
+    UserId: req.param('user_id')
+  }).then(function() {
+    res.redirect('/');
   });
 });
 
 router.get('/:user_id/tasks/:task_id/destroy', function (req, res) {
-  models.User.find({
-    where: { id: req.param('user_id') }
-  }).then(function(user) {
-    models.Task.find({
-      where: { id: req.param('task_id') }
-    }).then(function(task) {
-      task.setUser(null).then(function() {
-        task.destroy().then(function() {
-          res.redirect('/');
-        });
-      });
-    });
+  models.Task.destroy({
+    where: {
+      id: req.param('task_id')
+    }
+  }).then(function() {
+    res.redirect('/');
   });
 });
 

--- a/test/unit/task.test.js
+++ b/test/unit/task.test.js
@@ -4,13 +4,16 @@ var expect = require('expect.js');
 
 describe('models/task', function () {
   beforeEach(function () {
+    this.User = require('../../models').User;
     this.Task = require('../../models').Task;
   });
 
   describe('create', function () {
     it('creates a task', function () {
-      return this.Task.create({ title: 'a title' }).then(function (task) {
-        expect(task.title).to.equal('a title');
+      return this.User.create({ username: 'johndoe' }).bind(this).then(function (user) {
+        return this.Task.create({ title: 'a title', UserId: user.id }).then(function (task) {
+          expect(task.title).to.equal('a title');
+        });
       });
     });
   });


### PR DESCRIPTION
- put cascading delete behavior into model
- do not allow tasks without users (not handled by example UI)
- use Model#destroy method instead of Model#find followed by #destroy
- directly associate users when creating new tasks (one query less required)