### PR TITLE
Fix configuration for running tests

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -4,11 +4,8 @@
     "storage": "./db.development.sqlite"
   },
   "test": {
-    "username": "root",
-    "password": null,
-    "database": "database_test",
-    "host": "127.0.0.1",
-    "dialect": "mysql"
+    "dialect": "sqlite",
+    "storage": ":memory:"
   },
   "production": {
     "username": "root",

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "scripts": {
     "start": "node ./bin/www",
     "test": "npm run test-unit && npm run test-integration",
-    "test-unit": "./node_modules/.bin/mocha test/unit/*.test.js",
-    "test-integration": "./node_modules/.bin/mocha test/integration/*.test.js"
+    "test-unit": "cross-env NODE_ENV=test ./node_modules/.bin/mocha test/unit/*.test.js",
+    "test-integration": "cross-env NODE_ENV=test ./node_modules/.bin/mocha test/integration/*.test.js"
   },
   "dependencies": {
     "body-parser": "^1.15.2",
@@ -23,6 +23,7 @@
   },
   "devDependencies": {
     "bluebird": "^3.4.1",
+    "cross-env": "^3.1.3",
     "expect.js": "^0.3.1",
     "mocha": "^3.0.2",
     "supertest": "^2.0.0"


### PR DESCRIPTION
- Use cross-env to set NODE_ENV=test when invoking tests.
- Update config.json to use an in-memory sqlite database for tests.

Before this change, the tests were using the development configuration.