### PR TITLE
Fix breaking changes introduced with Sequelize 4.0.0

### DIFF
--- a/models/task.js
+++ b/models/task.js
@@ -5,7 +5,7 @@ module.exports = function(sequelize, DataTypes) {
     title: DataTypes.STRING
   });
   
-  Task associate = function(models) {
+  Task.associate = function(models) {
     // Using additional options like CASCADE etc for demonstration
     // Can also simply do Task.belongsTo(models.User);
     Task.belongsTo(models.User, {

--- a/models/task.js
+++ b/models/task.js
@@ -3,20 +3,18 @@
 module.exports = function(sequelize, DataTypes) {
   var Task = sequelize.define("Task", {
     title: DataTypes.STRING
-  }, {
-    classMethods: {
-      associate: function(models) {
-        // Using additional options like CASCADE etc for demonstration
-        // Can also simply do Task.belongsTo(models.User);
-        Task.belongsTo(models.User, {
-          onDelete: "CASCADE",
-          foreignKey: {
-            allowNull: false
-          }
-        });
-      }
-    }
   });
-
+  
+  Task associate = function(models) {
+    // Using additional options like CASCADE etc for demonstration
+    // Can also simply do Task.belongsTo(models.User);
+    Task.belongsTo(models.User, {
+      onDelete: "CASCADE",
+      foreignKey: {
+        allowNull: false
+      }
+    });
+  }
+  
   return Task;
 };

--- a/models/user.js
+++ b/models/user.js
@@ -3,13 +3,11 @@
 module.exports = function(sequelize, DataTypes) {
   var User = sequelize.define("User", {
     username: DataTypes.STRING
-  }, {
-    classMethods: {
-      associate: function(models) {
-        User.hasMany(models.Task)
-      }
-    }
   });
 
+  User.associate = function(models) {
+    User.hasMany(models.Task);
+  }
+  
   return User;
 };


### PR DESCRIPTION
In Sequelize 4.0.0 you no longer have classMethods and instanceMethods on Sequelize.define method's options parameter. I adapted the code to the new way to add classMethods.