### PR TITLE
Fix README.md for V4

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,9 @@ like this:
 ```js
 // task.js
 // ...
-classMethods: {
-  associate: function(models) {
+  Task.associate = function(models) {
+    // Using additional options like CASCADE etc for demonstration
+    // Can also simply do Task.belongsTo(models.User);
     Task.belongsTo(models.User, {
       onDelete: "CASCADE",
       foreignKey: {
@@ -86,18 +87,15 @@ classMethods: {
       }
     });
   }
-}
 // ...
 ```
 
 ```js
 // user.js
 // ...
-classMethods: {
-  associate: function(models) {
-    User.hasMany(models.Task)
+  User.associate = function(models) {
+    User.hasMany(models.Task);
   }
-}
 // ...
 ```
 


### PR DESCRIPTION
Since Sequelize V4, Sequelize Models are ES6 classes.
So you do not need to use classmethod when modeling.
Just uses the ES6 classes.

Only the README.md file has been modified for V4.