### PR TITLE
readme updates with useful details

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,11 @@ node_modules/.bin/sequelize model:create --name User --attributes username:strin
 node_modules/.bin/sequelize model:create --name Task --attributes title:string
 ```
 
+```bash
+# spaces matter when specifying multiple attributes, ex:
+node_modules/.bin/sequelize model:create --name Task --attributes title:string,body:string
+```
+
 We are using `.sequelizerc` setup change config path for migrations. You can read more about this in [migration docs](http://docs.sequelizejs.com/manual/tutorial/migrations.html#the-sequelizerc-file)
 
 ```js
@@ -76,6 +81,12 @@ const path = require('path');
 module.exports = {
   'config': path.resolve('config', 'config.js')
 }
+```
+
+Don't forget to modify the config.js file to export the json blob or `db:*` commands will fail. See `config/config.js`
+
+```js
+module.exports = //json blob
 ```
 
 You will now have a basic express application with some additional directories


### PR DESCRIPTION
provide additional details to make it easier for people to port the detailed instructions over to their own project setup without referencing main documentation. 
- Most models will have many attributes and specifying them as space delimited or comma delimited followed by a space generates a model with only the first attribute.
- Using sequelize cli init function generates a JSON blob. Adding the specified .sequelizerc results in syntax errors because the JSON blob needs to be exported.