### PR TITLE
added missing sequelize config var - needed for heroku setup

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -13,5 +13,6 @@ module.exports = {
     database: process.env.DB_NAME,
     host: process.env.DB_HOSTNAME,
     dialect: 'mysql',
+    use_env_variable: 'DATABASE_URL'
   }
 };


### PR DESCRIPTION
The 'deploy on heroku' was broken because of missing field in config.

I did some sniffing, the fix is based on [this issue](https://github.com/sequelize/express-example/issues/4) and [this PR](https://github.com/sequelize/express-example/pull/46/files)