### PR TITLE
Replace deprecated body-parser with built-in json.

### DIFF
--- a/express-main-example/express/app.js
+++ b/express-main-example/express/app.js
@@ -1,5 +1,4 @@
 const express = require('express');
-const bodyParser = require('body-parser');
 
 const routes = {
 	users: require('./routes/users'),
@@ -11,8 +10,8 @@ const routes = {
 
 const app = express();
 
-app.use(bodyParser.json());
-app.use(bodyParser.urlencoded({ extended: true }));
+app.use(express.json());
+app.use(express.urlencoded());
 
 // We create a wrapper to workaround async errors not being transmitted correctly.
 function makeHandlerAwareOfAsyncErrors(handler) {

--- a/express-main-example/package.json
+++ b/express-main-example/package.json
@@ -12,7 +12,6 @@
   },
   "license": "MIT",
   "dependencies": {
-    "body-parser": "^1.19.0",
     "express": "^4.17.1",
     "sequelize": "^6.3.3",
     "sqlite3": "^5.0.0"


### PR DESCRIPTION
A minor change to eliminate an error originated by the way body is parsed. Express adopted built-in method to parse json as you know, so I changed the relevant dependency.